### PR TITLE
Correctly find content-type parsers

### DIFF
--- a/src/pedestal_toolbox/params.clj
+++ b/src/pedestal_toolbox/params.clj
@@ -31,7 +31,7 @@
               (if-let [content-type (-> ctx
                                         (get-in [:request :content-type])
                                         blank->nil)]
-                (if (some #(re-matches % content-type) (keys parser-map))
+                (if (some #(re-find % content-type) (keys parser-map))
                   (try
                     (let [new-ctx ((:enter (body-params/body-params parser-map)) ctx)
                           request (:request new-ctx)]

--- a/test/pedestal_toolbox/params_test.clj
+++ b/test/pedestal_toolbox/params_test.clj
@@ -21,6 +21,13 @@
                  make-request
                  ((:enter (body-params)))
                  (get-in [:request :edn-params])))))
+    (testing "Doesn't 415 if charset is set"
+      (is (not= 415
+                (-> good-body
+                    make-request
+                    (assoc-in [:request :content-type] "application/edn; charset=UTF-8")
+                    ((:enter (body-params)))
+                    (get-in [:response :status])))))
     (testing "Returns a 400 (not a 500!) on a bad request"
       (is (= 400 (-> bad-body
                      make-request


### PR DESCRIPTION
`re-match` requires a regular expression to match the entire string. We want `re-find` which only check that the expression matches.

`body-params` was failing to find parsers for request with `Content-Type` headers set to values like `application/edn; charset=UTF-8` which is legal and good.

Discovered while trying to use [democracyworks/user-http-api](https://github.com/democracyworks/user-http-api) from Firefox, which likes to add the "charset" part of the content type.