### PR TITLE
Cors matcher

### DIFF
--- a/src/pedestal_toolbox/cors.clj
+++ b/src/pedestal_toolbox/cors.clj
@@ -3,4 +3,5 @@
 (defn domain-matcher-fn [patterns]
   (fn [origin]
     (boolean
-     (some #(re-matches % origin) patterns))))
+     (and origin
+          (some #(re-matches % origin) patterns)))))

--- a/src/pedestal_toolbox/cors.clj
+++ b/src/pedestal_toolbox/cors.clj
@@ -1,7 +1,6 @@
 (ns pedestal-toolbox.cors)
 
-(defn domain-matcher-fn [list-of-strings]
-  (let [patterns (map re-pattern list-of-strings)]
-    (fn [origin]
-      (boolean
-       (some #(re-matches % origin) patterns)))))
+(defn domain-matcher-fn [patterns]
+  (fn [origin]
+    (boolean
+     (some #(re-matches % origin) patterns))))

--- a/src/pedestal_toolbox/cors.clj
+++ b/src/pedestal_toolbox/cors.clj
@@ -1,0 +1,7 @@
+(ns pedestal-toolbox.cors)
+
+(defn domain-matcher-fn [list-of-strings]
+  (let [patterns (map re-pattern list-of-strings)]
+    (fn [origin]
+      (boolean
+       (some #(re-matches % origin) patterns)))))

--- a/test/pedestal_toolbox/cors_test.clj
+++ b/test/pedestal_toolbox/cors_test.clj
@@ -29,4 +29,7 @@
       (is (false? (f "https://google.com")))
       (is (true? (f "https://turbovote.org")))
       (is (false? (f "http://turbovote.org")))
-      (is (true? (f "http://vote.donaldtrump.com"))))))
+      (is (true? (f "http://vote.donaldtrump.com")))))
+  (testing "matcher handles nil gracefully (with false return)"
+    (let [f (domain-matcher-fn [#".+"])]
+      (is (false? (f nil))))))

--- a/test/pedestal_toolbox/cors_test.clj
+++ b/test/pedestal_toolbox/cors_test.clj
@@ -5,12 +5,24 @@
 (deftest cors-domain-matcher-fn-test
   (testing "make sure beta.turbovote.org is allowed"
     (let [f (domain-matcher-fn ["beta[.]turbovote[.]org"])]
-      (is (true? (f "beta.turbovote.org")))))
-  (testing "make sure ourtime-beta.turbovote.org is allowed"
-    (let [f (domain-matcher-fn [".*[.]turbovote[.]org"])]
       (is (true? (f "beta.turbovote.org")))
-      (is (true? (f "ourtime-beta.turbovote.org")))))
-  (testing "make sure ourtime-beta.turbovote.org is allowed"
-    (let [f (domain-matcher-fn [".*"])]
+      (is (false? (f "ourtime-beta.turbovote.org")))))
+  (testing "make sure turbovote.org domains are allowed"
+    (let [f (domain-matcher-fn ["(.*[.])?turbovote[.]org"])]
       (is (true? (f "beta.turbovote.org")))
-      (is (true? (f "ourtime-beta.turbovote.org"))))))
+      (is (true? (f "ourtime-beta.turbovote.org")))
+      (is (false? (f "google.com")))
+      (is (true? (f "turbovote.org")))))
+  (testing "make sure wildcard domain works"
+    (let [f (domain-matcher-fn [".+"])]
+      (is (true? (f "beta.turbovote.org")))
+      (is (true? (f "ourtime-beta.turbovote.org")))
+      (is (false? (f "")))))
+  (testing "make sure turbovote.org domains are allowed"
+    (let [f (domain-matcher-fn ["(.+[.])?turbovote[.]org"
+                                "vote[.]donaldtrump[.]com"])]
+      (is (true? (f "beta.turbovote.org")))
+      (is (true? (f "ourtime-beta.turbovote.org")))
+      (is (false? (f "google.com")))
+      (is (true? (f "turbovote.org")))
+      (is (true? (f "vote.donaldtrump.com"))))))

--- a/test/pedestal_toolbox/cors_test.clj
+++ b/test/pedestal_toolbox/cors_test.clj
@@ -1,0 +1,16 @@
+(ns pedestal-toolbox.cors-test
+  (:require [pedestal-toolbox.cors :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest cors-domain-matcher-fn-test
+  (testing "make sure beta.turbovote.org is allowed"
+    (let [f (domain-matcher-fn ["beta[.]turbovote[.]org"])]
+      (is (true? (f "beta.turbovote.org")))))
+  (testing "make sure ourtime-beta.turbovote.org is allowed"
+    (let [f (domain-matcher-fn [".*[.]turbovote[.]org"])]
+      (is (true? (f "beta.turbovote.org")))
+      (is (true? (f "ourtime-beta.turbovote.org")))))
+  (testing "make sure ourtime-beta.turbovote.org is allowed"
+    (let [f (domain-matcher-fn [".*"])]
+      (is (true? (f "beta.turbovote.org")))
+      (is (true? (f "ourtime-beta.turbovote.org"))))))

--- a/test/pedestal_toolbox/cors_test.clj
+++ b/test/pedestal_toolbox/cors_test.clj
@@ -4,25 +4,25 @@
 
 (deftest cors-domain-matcher-fn-test
   (testing "make sure beta.turbovote.org is allowed"
-    (let [f (domain-matcher-fn ["https://beta[.]turbovote[.]org"])]
+    (let [f (domain-matcher-fn [#"https://beta[.]turbovote[.]org"])]
       (is (true? (f "https://beta.turbovote.org")))
       (is (false? (f "https://ourtime-beta.turbovote.org")))))
   (testing "make sure turbovote.org domains are allowed"
-    (let [f (domain-matcher-fn ["https://(.+[.])?turbovote[.]org"])]
+    (let [f (domain-matcher-fn [#"https://(.+[.])?turbovote[.]org"])]
       (is (true? (f "https://beta.turbovote.org")))
       (is (true? (f "https://ourtime-beta.turbovote.org")))
       (is (false? (f "http://google.com")))
       (is (true? (f "https://turbovote.org")))))
   (testing "make sure wildcard domain works"
-    (let [f (domain-matcher-fn [".+"])]
+    (let [f (domain-matcher-fn [#".+"])]
       (is (true? (f "https://beta.turbovote.org")))
       (is (true? (f "https://ourtime-beta.turbovote.org")))
       (is (true? (f "http://localhost:8080")))
       (is (true? (f "http://localdocker:8080")))
       (is (false? (f "")))))
   (testing "make sure turbovote.org domains are allowed"
-    (let [f (domain-matcher-fn ["https://(.+[.])?turbovote[.]org"
-                                "http://vote[.]donaldtrump[.]com"])]
+    (let [f (domain-matcher-fn [#"https://(.+[.])?turbovote[.]org"
+                                #"http://vote[.]donaldtrump[.]com"])]
       (is (true? (f "https://beta.turbovote.org")))
       (is (true? (f "https://ourtime-beta.turbovote.org")))
       (is (false? (f "http://google.com")))

--- a/test/pedestal_toolbox/cors_test.clj
+++ b/test/pedestal_toolbox/cors_test.clj
@@ -4,25 +4,29 @@
 
 (deftest cors-domain-matcher-fn-test
   (testing "make sure beta.turbovote.org is allowed"
-    (let [f (domain-matcher-fn ["beta[.]turbovote[.]org"])]
-      (is (true? (f "beta.turbovote.org")))
-      (is (false? (f "ourtime-beta.turbovote.org")))))
+    (let [f (domain-matcher-fn ["https://beta[.]turbovote[.]org"])]
+      (is (true? (f "https://beta.turbovote.org")))
+      (is (false? (f "https://ourtime-beta.turbovote.org")))))
   (testing "make sure turbovote.org domains are allowed"
-    (let [f (domain-matcher-fn ["(.*[.])?turbovote[.]org"])]
-      (is (true? (f "beta.turbovote.org")))
-      (is (true? (f "ourtime-beta.turbovote.org")))
-      (is (false? (f "google.com")))
-      (is (true? (f "turbovote.org")))))
+    (let [f (domain-matcher-fn ["https://(.+[.])?turbovote[.]org"])]
+      (is (true? (f "https://beta.turbovote.org")))
+      (is (true? (f "https://ourtime-beta.turbovote.org")))
+      (is (false? (f "http://google.com")))
+      (is (true? (f "https://turbovote.org")))))
   (testing "make sure wildcard domain works"
     (let [f (domain-matcher-fn [".+"])]
-      (is (true? (f "beta.turbovote.org")))
-      (is (true? (f "ourtime-beta.turbovote.org")))
+      (is (true? (f "https://beta.turbovote.org")))
+      (is (true? (f "https://ourtime-beta.turbovote.org")))
+      (is (true? (f "http://localhost:8080")))
+      (is (true? (f "http://localdocker:8080")))
       (is (false? (f "")))))
   (testing "make sure turbovote.org domains are allowed"
-    (let [f (domain-matcher-fn ["(.+[.])?turbovote[.]org"
-                                "vote[.]donaldtrump[.]com"])]
-      (is (true? (f "beta.turbovote.org")))
-      (is (true? (f "ourtime-beta.turbovote.org")))
-      (is (false? (f "google.com")))
-      (is (true? (f "turbovote.org")))
-      (is (true? (f "vote.donaldtrump.com"))))))
+    (let [f (domain-matcher-fn ["https://(.+[.])?turbovote[.]org"
+                                "http://vote[.]donaldtrump[.]com"])]
+      (is (true? (f "https://beta.turbovote.org")))
+      (is (true? (f "https://ourtime-beta.turbovote.org")))
+      (is (false? (f "http://google.com")))
+      (is (false? (f "https://google.com")))
+      (is (true? (f "https://turbovote.org")))
+      (is (false? (f "http://turbovote.org")))
+      (is (true? (f "http://vote.donaldtrump.com"))))))


### PR DESCRIPTION
Previously we were matching cors origins with either a list of strings or the special case keyword `:all`. Now that we're creating partner sites, it will be too much trouble to add domains for each http-api service each time a partner site is created. This PR defines a function which creates a CORS matcher for pedestal that interprets a list of strings as a list of regexes. The regexes can be more general than a single domain. For instance, we propose using `["(.+[.])?turbovote.org"]` to represent turbovote.org and all hosts on the domain. For testing/dev/krakenstein, we can use this: `[".+"]`.

This is a non-breaking change, but not a bug fix, so I suggest we release this as 0.7.0.

This is done as part of the partner sites work, [Pivotal Card](https://www.pivotaltracker.com/story/show/112013999).